### PR TITLE
feat(auth): add user profile creation during signup

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -37,6 +37,25 @@ export class AuthService {
         throw new UnauthorizedException(authError.message);
       }
 
+      // Se o usuário foi criado com sucesso, criar também na tabela public.users
+      if (authData.user) {
+        const { error: dbError } = await this.supabase
+          .from('users')
+          .insert({
+            id: authData.user.id,
+            email: authData.user.email,
+            name: name,
+          });
+
+        if (dbError) {
+          console.error('Erro ao criar usuário na tabela users:', dbError);
+          // Não falhar o registro se o usuário já existir na tabela
+          if (!dbError.message.includes('duplicate key')) {
+            throw new UnauthorizedException('Erro ao criar perfil do usuário');
+          }
+        }
+      }
+
       return {
         user: authData.user,
         session: authData.session,

--- a/src/prompts/dto/create-prompt.dto.ts
+++ b/src/prompts/dto/create-prompt.dto.ts
@@ -1,5 +1,5 @@
 import { IsNotEmpty, IsString, IsEnum, IsArray, IsOptional, IsBoolean, MaxLength, MinLength } from 'class-validator';
-import { PromptCategory } from '../entities/prompt.entity';
+import { PromptCategory } from '../../types/database.types';
 
 export class CreatePromptDto {
   @IsNotEmpty()

--- a/src/prompts/prompts.controller.ts
+++ b/src/prompts/prompts.controller.ts
@@ -14,7 +14,7 @@ import { PromptsService } from './prompts.service';
 import { CreatePromptDto } from './dto/create-prompt.dto';
 import { UpdatePromptDto } from './dto/update-prompt.dto';
 import { SupabaseAuthGuard } from '../auth/guards/supabase-auth.guard';
-import { PromptCategory } from './entities/prompt.entity';
+import { PromptCategory } from '../types/database.types';
 
 @Controller('prompts')
 @UseGuards(SupabaseAuthGuard)

--- a/src/prompts/prompts.service.ts
+++ b/src/prompts/prompts.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, NotFoundException, Inject } from '@nestjs/common';
 import { SupabaseClient } from '@supabase/supabase-js';
-import { Database, Prompt, PromptCategory } from '../types/database.types';
+import { Database, Prompt, PromptCategory, PromptInsert, PromptUpdate } from '../types/database.types';
 import { CreatePromptDto } from './dto/create-prompt.dto';
 import { UpdatePromptDto } from './dto/update-prompt.dto';
 

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -11,6 +11,33 @@ export enum PromptCategory {
 export interface Database {
   public: {
     Tables: {
+      users: {
+        Row: {
+          id: string
+          name: string
+          email: string
+          password?: string
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id: string
+          name: string
+          email: string
+          password?: string
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          name?: string
+          email?: string
+          password?: string
+          created_at?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
       prompts: {
         Row: {
           id: string
@@ -66,3 +93,7 @@ export interface Database {
 export type Prompt = Database['public']['Tables']['prompts']['Row'];
 export type PromptInsert = Database['public']['Tables']['prompts']['Insert'];
 export type PromptUpdate = Database['public']['Tables']['prompts']['Update'];
+
+export type User = Database['public']['Tables']['users']['Row'];
+export type UserInsert = Database['public']['Tables']['users']['Insert'];
+export type UserUpdate = Database['public']['Tables']['users']['Update'];


### PR DESCRIPTION
Create user profile in public.users table when new user registers. Also centralize database types by moving PromptCategory to shared types file and add User type definitions.